### PR TITLE
Patch out lalsuite requirement

### DIFF
--- a/recipe/lalsuite-requirements.patch
+++ b/recipe/lalsuite-requirements.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 1ae8de9..8363ce4 100644
+--- a/setup.py
++++ b/setup.py
+@@ -53,7 +53,6 @@ setup(
+         "gwdetchar",
+         "gwsumm",
+         "pycondor",
+-        "lalsuite>=7.3",
+         "loguru",
+         "json5",
+         "seaborn",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,21 +22,21 @@ requirements:
     - setuptools-scm >=6.2
     - wheel
   run:
-    - python
-    - numpy
-    - matplotlib-base
-    - scipy >=1.8.0,<1.14.0
-    - bilby >=1.4
-    - gwpy >=3.0.4
     - astropy >=5.2
     - gwdetchar
     - gwsumm
-    - pycondor
+    - bilby >=1.4
+    - gwpy >=3.0.4
+    - json5
     - lalsuite >=7.3
     - loguru
-    - json5
-    - seaborn
+    - matplotlib-base
+    - numpy
     - pycbc
+    - pycondor
+    - python
+    - scipy >=1.8.0,<1.14.0
+    - seaborn
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,14 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pygwb-{{ version }}.tar.gz
   sha256: 675da6be45411e39b0032913499de3189abcf2f3bc4e48ff3bd208f86d22fa1d
+  patches:
+    # remove lalsuite requirement, in conda we can specify python-lal
+    - lalsuite-requirements.patch
 
 build:
   skip: true  # [win or py>=312]
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -28,13 +31,13 @@ requirements:
     - bilby >=1.4
     - gwpy >=3.0.4
     - json5
-    - lalsuite >=7.3
     - loguru
     - matplotlib-base
     - numpy
     - pycbc
     - pycondor
     - python
+    - python-lal
     - scipy >=1.8.0,<1.14.0
     - seaborn
 


### PR DESCRIPTION
This PR adds a simple patch to excise the `lalsuite` requirement from the Python metadata and replace it with a specific Conda requirement on `python-lal` - this is the only part of LALSuite that is actually needed. This patch should make isolated environments for PyGWB smaller since the rest of LALSuite shouldn't need to be installed.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
